### PR TITLE
Fix GitHub release workflow step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,14 +16,15 @@ jobs:
           fetch-depth: 0
       - name: "Install poetry"
         run: pipx install poetry
-      - name: "Export package version"
+      - name: "Export package information"
+        id: export
         run: |
           VERSION=$(poetry version --short)
           if [ "$(git tag -l "${VERSION}")" ]; then
             echo "Tag ${VERSION} already exists. Please bump the project to a greater version."
             exit 1
           fi
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
       - name: "Build package"
         run: poetry build
       - name: "Store the distribution packages"
@@ -46,10 +47,10 @@ jobs:
           path: dist/
       - name: "Create GitHub release"
         run: |
-          git tag "${{ env.VERSION }}"
-          git push origin "${{ env.VERSION }}"
-          gh release create "${{ env.VERSION }}" --generate-notes --title "${{ env.VERSION }}"
-          gh release upload "${{ env.VERSION }}" dist/*.{tar.gz,whl}
+          git tag "${{ needs.export.outputs.VERSION }}"
+          git push origin "${{ needs.export.outputs.VERSION }}"
+          gh release create "${{ needs.export.outputs.VERSION }}" --generate-notes --title "${{ needs.export.outputs.VERSION }}"
+          gh release upload "${{ needs.export.outputs.VERSION }}" dist/*.{tar.gz,whl}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR fixes the GitHub release workflow step, by using `GITHUB_OUTPUT` to populate cross-job variables (see [CI failure](https://github.com/canonical/postgresql-ldap-sync/actions/runs/13196090784/job/36837671146)).

References:
- [Why `GITHUB_ENV` is not enough to share cross-job values](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable).
- [Why `GITHUB_OUTPUT` is recommended to share cross-job values](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter).