### PR TITLE
Add PyPi project description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,15 +9,15 @@ requires-python = ">=3.10"
 license = "Apache-2.0"
 version = "0.1.0"
 authors = [
-    {name = "Sinclert Perez", email = "sinclert.perez@canonical.com"}
+    { name = "Sinclert Perez", email = "sinclert.perez@canonical.com" }
 ]
 maintainers = [
-    {name = "Carl Csaposs", email = "carl.csaposs@canonical.com"},
-    {name = "Dragomir Penev", email = "dragomir.penev@canonical.com"},
-    {name = "Marcelo Neppel", email = "marcelo.neppel@canonical.com"},
-    {name = "Paulo Silveira", email = "paulo.machado@canonical.com"},
-    {name = "Shayan Patel", email = "shayan.patel@canonical.com"},
-    {name = "Sinclert Perez", email = "sinclert.perez@canonical.com"},
+    { name = "Carl Csaposs", email = "carl.csaposs@canonical.com" },
+    { name = "Dragomir Penev", email = "dragomir.penev@canonical.com" },
+    { name = "Marcelo Neppel", email = "marcelo.neppel@canonical.com" },
+    { name = "Paulo Silveira", email = "paulo.machado@canonical.com" },
+    { name = "Shayan Patel", email = "shayan.patel@canonical.com" },
+    { name = "Sinclert Perez", email = "sinclert.perez@canonical.com" },
 ]
 dependencies = [
     "psycopg2 >= 2.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "postgresql-ldap-sync"
 description = "Project to sync LDAP users / groups to PostgreSQL"
 requires-python = ">=3.10"
 license = "Apache-2.0"
+readme = "README.md"
 version = "0.1.0"
 authors = [
     { name = "Sinclert Perez", email = "sinclert.perez@canonical.com" }


### PR DESCRIPTION
This PR fixes the PyPi project description for this package, as it is [currently empty](https://pypi.org/project/postgresql-ldap-sync/).