### PR TITLE
Protect PG clients against query injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][docs-changelog], and the version adheres to [Semantic Versioning][docs-semver].
 
 
+## Unreleased
+### Added
+- Ability to grant / revoke role membership in bulk.
+### Fixed
+- Possible query injection when PG client used in isolation.
+
 ## [0.1.0][changes-0.1.0] - 2025-02-04
 ### Added
 - Initial functionality.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,17 +72,28 @@ line-length = 99
 
 [tool.ruff.lint]
 explicit-preview-rules = true
-select = ["A", "E", "W", "F", "C", "N", "D", "I", "CPY001"]
+select = [
+    "A",      # Activate flake8-builtins
+    "C",      # Acticate mccabe
+    "D",      # Activate pydocstyle
+    "E",      # Activate pycodestyle errors
+    "W",      # Activate pycodestyle warnings
+    "F",      # Acticate pyflakes
+    "I",      # Activate isort
+    "N",      # Activate PEP8 naming
+    "S608",   # Acticate flake8-bandit query injection
+    "CPY001", # Activate copyright notice check
+]
 ignore = [
-    "D100", # Ignore D100 Missing docstring in public module
-    "D104", # Ignore D104 Missing docstring in __init__
-    "E731", # Ignore E731 Do not assign a `lambda` expression
+    "D100",   # Ignore D100 Missing docstring in public module
+    "D104",   # Ignore D104 Missing docstring in __init__
+    "E731",   # Ignore E731 Do not assign a `lambda` expression
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = [
-    "F401", # Ignore F401 Imported but unused
-    "F403", # Ignore F403 Unable to detect undefined names
+    "F401",   # Ignore F401 Imported but unused
+    "F403",   # Ignore F403 Unable to detect undefined names
 ]
 
 [tool.ruff.lint.flake8-copyright]

--- a/src/postgresql_ldap_sync/clients/psql/base.py
+++ b/src/postgresql_ldap_sync/clients/psql/base.py
@@ -31,13 +31,13 @@ class BasePostgreClient(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def grant_group_membership(self, group: str, users: list[str]) -> None:
-        """Grant group membership to a list of users."""
+    def grant_group_memberships(self, groups: list[str], users: list[str]) -> None:
+        """Grant groups membership to a list of users."""
         raise NotImplementedError()
 
     @abstractmethod
-    def revoke_group_membership(self, group: str, users: list[str]) -> None:
-        """Revoke group membership from a list of users."""
+    def revoke_group_memberships(self, groups: list[str], users: list[str]) -> None:
+        """Revoke groups membership from a list of users."""
         raise NotImplementedError()
 
     @abstractmethod

--- a/src/postgresql_ldap_sync/clients/psql/dummy.py
+++ b/src/postgresql_ldap_sync/clients/psql/dummy.py
@@ -30,12 +30,12 @@ class DummyPostgresClient(BasePostgreClient):
         """Delete a group in PostgreSQL."""
         return None
 
-    def grant_group_membership(self, group: str, users: list[str]) -> None:
-        """Grant group membership to a list of users."""
+    def grant_group_memberships(self, groups: list[str], users: list[str]) -> None:
+        """Grant groups membership to a list of users."""
         return None
 
-    def revoke_group_membership(self, group: str, users: list[str]) -> None:
-        """Revoke group membership from a list of users."""
+    def revoke_group_memberships(self, groups: list[str], users: list[str]) -> None:
+        """Revoke groups membership from a list of users."""
         return None
 
     def search_users(self) -> list[str]:

--- a/src/postgresql_ldap_sync/clients/psql/postgres.py
+++ b/src/postgresql_ldap_sync/clients/psql/postgres.py
@@ -8,6 +8,7 @@ from typing import Iterator
 import psycopg2
 from psycopg2.errors import DatabaseError, ProgrammingError
 from psycopg2.extras import RealDictCursor, RealDictRow
+from psycopg2.sql import SQL, Composable, Identifier
 
 from ...models import GroupMembers
 from .base import BasePostgreClient
@@ -56,7 +57,7 @@ class DefaultPostgresClient(BasePostgreClient):
             autocommit=auto_commit,
         )
 
-    def _execute_query(self, query: str) -> list[RealDictRow]:
+    def _execute_query(self, query: Composable) -> list[RealDictRow]:
         """Execute a SQL query and return the results."""
         with self._client.cursor(cursor_factory=RealDictCursor) as cursor:
             try:
@@ -68,75 +69,96 @@ class DefaultPostgresClient(BasePostgreClient):
             else:
                 return cursor.fetchall()
 
-    def _create_role(self, role: str, options: str) -> None:
+    def _create_role(self, role: str, login: bool, inherit: bool) -> None:
         """Create a role in PostgreSQL."""
-        query = f"CREATE ROLE {role} {options}"
+        quoted_role = Identifier(role)
+        quoted_options = " ".join([
+            "LOGIN" if login else "NOLOGIN",
+            "INHERIT" if inherit else "NOINHERIT",
+        ])
+
+        query = SQL(f"CREATE ROLE {{role}} WITH {quoted_options}")
+        query = query.format(role=quoted_role)
 
         try:
             self._execute_query(query)
         except ProgrammingError:
-            logger.error(f"Could not create role '{role}'")
+            logger.error(f"Could not create role {quoted_role}")
 
     def _delete_role(self, role: str) -> None:
         """Delete a role in PostgreSQL."""
-        query = f"DROP ROLE {role}"
+        quoted_role = Identifier(role)
+
+        query = SQL("DROP ROLE {role}")
+        query = query.format(role=quoted_role)
 
         try:
             self._execute_query(query)
         except ProgrammingError:
-            logger.error(f"Could not delete role '{role}'")
+            logger.error(f"Could not delete role {quoted_role}")
 
-    def _grant_role_membership(self, role: str, roles: list[str], options: str) -> None:
+    def _grant_role_memberships(self, groups: list[str], users: list[str]) -> None:
         """Grant role membership to a list of roles."""
-        roles = ",".join(roles)
-        query = f"GRANT {role} TO {roles} {options}"
+        quoted_groups = SQL(",").join(Identifier(group) for group in groups)
+        quoted_users = SQL(",").join(Identifier(user) for user in users)
+
+        query = SQL("GRANT {groups} TO {users}")
+        query = query.format(
+            groups=quoted_groups,
+            users=quoted_users,
+        )
 
         try:
             self._execute_query(query)
         except ProgrammingError:
-            logger.error(f"Could not grant memberships to role '{role}'")
+            logger.error(f"Could not grant memberships to groups {quoted_groups}")
 
-    def _revoke_role_membership(self, role: str, roles: list[str]) -> None:
+    def _revoke_role_memberships(self, groups: list[str], users: list[str]) -> None:
         """Revoke role membership from a list of roles."""
-        roles = ",".join(roles)
-        query = f"REVOKE {role} FROM {roles}"
+        quoted_groups = SQL(",").join(Identifier(group) for group in groups)
+        quoted_users = SQL(",").join(Identifier(user) for user in users)
 
+        query = SQL("REVOKE {groups} FROM {users}")
+        query = query.format(
+            groups=quoted_groups,
+            users=quoted_users,
+        )
         try:
             self._execute_query(query)
         except ProgrammingError:
-            logger.error(f"Could not revoke memberships from role '{role}'")
+            logger.error(f"Could not revoke memberships from groups {quoted_groups}")
 
     def close(self) -> None:
         """Close the psycopg2 cursor and connection."""
         self._client.close()
 
-    def create_user(self, user: str, options: str = "LOGIN") -> None:
+    def create_user(self, user: str, login: bool = True, inherit: bool = True) -> None:
         """Create a user in PostgreSQL."""
-        self._create_role(user, options)
+        self._create_role(user, login, inherit)
 
     def delete_user(self, user: str) -> None:
         """Delete a user in PostgreSQL."""
         self._delete_role(user)
 
-    def create_group(self, group: str, options: str = "NOLOGIN") -> None:
+    def create_group(self, group: str, login: bool = False, inherit: bool = False) -> None:
         """Create a group in PostgreSQL."""
-        self._create_role(group, options)
+        self._create_role(group, login, inherit)
 
     def delete_group(self, group: str) -> None:
         """Delete a group in PostgreSQL."""
         self._delete_role(group)
 
-    def grant_group_membership(self, group: str, users: list[str], options: str = "") -> None:
-        """Grant group membership to a list of users."""
-        self._grant_role_membership(group, users, options)
+    def grant_group_memberships(self, groups: list[str], users: list[str]) -> None:
+        """Grant groups membership to a list of users."""
+        self._grant_role_memberships(groups, users)
 
-    def revoke_group_membership(self, group: str, users: list[str]) -> None:
-        """Revoke group membership from a list of users."""
-        self._revoke_role_membership(group, users)
+    def revoke_group_memberships(self, groups: list[str], users: list[str]) -> None:
+        """Revoke groups membership from a list of users."""
+        self._revoke_role_memberships(groups, users)
 
     def search_users(self) -> Iterator[str]:
         """Search for PostgreSQL users."""
-        query = (
+        query = SQL(
             "SELECT rolname "
             "FROM pg_catalog.pg_roles "
             "WHERE rolcanlogin AND oid IN (SELECT member from pg_catalog.pg_auth_members) "
@@ -151,7 +173,7 @@ class DefaultPostgresClient(BasePostgreClient):
 
     def search_groups(self) -> Iterator[str]:
         """Search for PostgreSQL groups."""
-        query = (
+        query = SQL(
             "SELECT rolname "
             "FROM pg_catalog.pg_roles "
             "WHERE rolcanlogin AND oid NOT IN (SELECT member from pg_catalog.pg_auth_members) "
@@ -166,7 +188,7 @@ class DefaultPostgresClient(BasePostgreClient):
 
     def search_group_memberships(self) -> Iterator[GroupMembers]:
         """Search for PostgreSQL group memberships."""
-        query = (
+        query = SQL(
             "SELECT roles_2.rolname as group, roles_1.rolname as user "
             "FROM pg_catalog.pg_roles roles_1 "
             "JOIN pg_catalog.pg_auth_members memberships ON (memberships.member=roles_1.oid) "

--- a/src/postgresql_ldap_sync/syncher.py
+++ b/src/postgresql_ldap_sync/syncher.py
@@ -72,8 +72,8 @@ class Synchronizer:
 
         for match in matches:
             if match.should_grant and "GRANT" in actions:
-                self._psql_client.grant_group_membership(match.group_name, [match.user_name])
+                self._psql_client.grant_group_memberships([match.group_name], [match.user_name])
             elif match.should_revoke and "REVOKE" in actions:
-                self._psql_client.revoke_group_membership(match.group_name, [match.user_name])
+                self._psql_client.revoke_group_memberships([match.group_name], [match.user_name])
             elif match.should_keep and "KEEP" in actions:
                 pass

--- a/tests/clients/psql/test_postgres_client.py
+++ b/tests/clients/psql/test_postgres_client.py
@@ -25,16 +25,16 @@ class TestDefaultPostgresClient:
             auto_commit=False,
         )
 
-        client.create_user("user_1", "LOGIN")
-        client.create_user("user_2", "LOGIN")
-        client.create_user("user_3", "NOLOGIN")
+        client.create_user("user_1", login=True)
+        client.create_user("user_2", login=True)
+        client.create_user("user_3", login=False)
 
-        client.create_group("group_1", "LOGIN")
-        client.create_group("group_2", "LOGIN")
-        client.create_group("group_3", "NOLOGIN")
+        client.create_group("group_1", login=True)
+        client.create_group("group_2", login=True)
+        client.create_group("group_3", login=False)
 
-        client.grant_group_membership("group_1", ["user_1", "user_2"])
-        client.grant_group_membership("group_2", ["user_2", "user_3"])
+        client.grant_group_memberships(["group_1"], ["user_1", "user_2"])
+        client.grant_group_memberships(["group_2"], ["user_2", "user_3"])
 
         yield client
 

--- a/tests/test_syncher.py
+++ b/tests/test_syncher.py
@@ -93,8 +93,8 @@ class TestSynchronizer:
     def test_sync_group_memberships(self, synchronizer: Synchronizer):
         """Test the creation / deletion of LDAP memberships into PostgreSQL."""
         with (
-            patch.object(synchronizer._psql_client, "grant_group_membership") as grant_member,
-            patch.object(synchronizer._psql_client, "revoke_group_membership") as revoke_member,
+            patch.object(synchronizer._psql_client, "grant_group_memberships") as grant_member,
+            patch.object(synchronizer._psql_client, "revoke_group_memberships") as revoke_member,
         ):
             synchronizer.sync_group_memberships(actions=["GRANT"])
             grant_member.assert_called()


### PR DESCRIPTION
This PR leverages [psycopg2.sql](https://www.psycopg.org/docs/sql.html) module in order to wrap every single query issued by the `DefaultPostgreSQL` client, in order to dynamically build the queries in a safe manner.

Before these changes, if such client gets imported and used by a downstream application, without using it as a initialization argument to the `Synchronizer` class (where all the query values come from a controlled environment), the application could suffer from a query injection attack.

### Additional changes
- Added the ability to grant / revoke group memberships in bulk.