### PR TITLE
Fix PostgreSQL user / group definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 - Ability to grant / revoke role membership in bulk.
 ### Fixed
 - Possible query injection when PG client used in isolation.
+- PostgreSQL user and group definitions. Now based on log-in capability.
 
 ## [0.1.0][changes-0.1.0] - 2025-02-04
 ### Added

--- a/tests/clients/psql/test_postgres_client.py
+++ b/tests/clients/psql/test_postgres_client.py
@@ -25,20 +25,39 @@ class TestDefaultPostgresClient:
             auto_commit=False,
         )
 
-        client.create_user("user_1", login=True)
-        client.create_user("user_2", login=True)
-        client.create_user("user_3", login=False)
+        client.create_user("user_1")
+        client.create_user("user_2")
+        client.create_user("user_3")
 
-        client.create_group("group_1", login=True)
-        client.create_group("group_2", login=True)
-        client.create_group("group_3", login=False)
+        client.create_group("group_1")
+        client.create_group("group_2")
+        client.create_group("group_3")
 
         client.grant_group_memberships(["group_1"], ["user_1", "user_2"])
         client.grant_group_memberships(["group_2"], ["user_2", "user_3"])
+        client.grant_group_memberships(["group_3"], ["group_1"])
 
         yield client
 
         client.close()
+
+    def test_create_user(self, client: DefaultPostgresClient):
+        """Test the create_user functionality."""
+        client.create_user("john")
+
+        users = client.search_users()
+        users = list(users)
+
+        assert "john" in users
+
+    def test_create_group(self, client: DefaultPostgresClient):
+        """Test the create_user functionality."""
+        client.create_group("group_rw")
+
+        groups = client.search_groups()
+        groups = list(groups)
+
+        assert "group_rw" in groups
 
     def test_search_users(self, client: DefaultPostgresClient):
         """Test the search_users functionality."""
@@ -47,7 +66,7 @@ class TestDefaultPostgresClient:
 
         assert "user_1" in users
         assert "user_2" in users
-        assert "user_3" not in users
+        assert "user_3" in users
 
     def test_search_groups(self, client: DefaultPostgresClient):
         """Test the search_groups functionality."""
@@ -56,7 +75,7 @@ class TestDefaultPostgresClient:
 
         assert "group_1" in groups
         assert "group_2" in groups
-        assert "group_3" not in groups
+        assert "group_3" in groups
 
     def test_search_group_memberships(self, client: DefaultPostgresClient):
         """Test the search_group_memberships functionality."""
@@ -65,4 +84,4 @@ class TestDefaultPostgresClient:
 
         assert GroupMembers("group_1", ["user_1", "user_2"]) in memberships
         assert GroupMembers("group_2", ["user_2", "user_3"]) in memberships
-        assert GroupMembers("group_3", []) not in memberships
+        assert GroupMembers("group_3", ["group_1"]) not in memberships


### PR DESCRIPTION
This PR reconsiders the definition of a PostgreSQL _user_ and _group_, to be aligned with real world scenarios, where groups could be members of other groups in order to distribute a set of permissions. The proof that this distinction is on the right direction, is that the `DefaultPostgreSQL` client can now leverage system-level views such as [pg_user](https://www.postgresql.org/docs/16/view-pg-user.html) and [pg_group](https://www.postgresql.org/docs/16/view-pg-group.html).

**Before:**
- A _user_ is a role that has `LOGIN `capabilities, and belongs to another role.
- A _group_ is a role that has no `LOGIN` capabilities, and does not belong to another role.

**Proposal:**
- A _user_ is a role that has `LOGIN` capabilities.
- A _group_ is a role that has no `LOGIN` capabilities.