### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 ## Unreleased
 ### Added
+### Fixed
+
+## [0.2.0][changes-0.2.0] - 2025-02-17
+### Added
 - Ability to grant / revoke role membership in bulk.
 ### Fixed
 - Possible query injection when PG client used in isolation.
@@ -19,5 +23,6 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 
 [changes-0.1.0]: https://github.com/canonical/postgresql-ldap-sync/releases/tag/v0.1.0
+[changes-0.2.0]: https://github.com/canonical/postgresql-ldap-sync/compare/v0.1.0...v0.2.0
 [docs-changelog]: https://keepachangelog.com/en/1.0.0/
 [docs-semver]: https://semver.org/spec/v2.0.0.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Project to sync LDAP users / groups to PostgreSQL"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 readme = "README.md"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     { name = "Sinclert Perez", email = "sinclert.perez@canonical.com" }
 ]


### PR DESCRIPTION
This PR makes the necessary changes to release version `0.2.0`.

Depends on https://github.com/canonical/postgresql-ldap-sync/pull/6.