### PR TITLE
Allow scoped user / group searches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
       - name: "Install binaries"
         run: |
+          sudo apt update
           sudo apt install libldap2-dev
           sudo apt install libsasl2-dev
       - name: "Set up Python"
@@ -44,6 +45,7 @@ jobs:
         uses: actions/checkout@v4
       - name: "Install binaries"
         run: |
+          sudo apt update
           sudo apt install libldap2-dev
           sudo apt install libsasl2-dev
       - name: "Set up Python"
@@ -92,6 +94,7 @@ jobs:
         run: docker restart glauth
       - name: "Install binaries"
         run: |
+          sudo apt update
           sudo apt install libldap2-dev
           sudo apt install libsasl2-dev
       - name: "Set up Python"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 ## Unreleased
 ### Added
+- Ability to search users / groups in a scoped manner.
 ### Fixed
 
 ## [0.2.0][changes-0.2.0] - 2025-02-17

--- a/tests/clients/psql/test_postgres_client.py
+++ b/tests/clients/psql/test_postgres_client.py
@@ -59,23 +59,45 @@ class TestDefaultPostgresClient:
 
         assert "group_rw" in groups
 
-    def test_search_users(self, client: DefaultPostgresClient):
-        """Test the search_users functionality."""
+    def test_search_users_scoped(self, client: DefaultPostgresClient):
+        """Test the search_users functionality from a group."""
+        users = client.search_users(from_group="group_1")
+        users = list(users)
+
+        assert "user_1" in users
+        assert "user_2" in users
+        assert "user_3" not in users
+        assert len(users) == len(set(users))
+
+    def test_search_users_unscoped(self, client: DefaultPostgresClient):
+        """Test the search_users functionality from any group."""
         users = client.search_users()
         users = list(users)
 
         assert "user_1" in users
         assert "user_2" in users
         assert "user_3" in users
+        assert len(users) == len(set(users))
 
-    def test_search_groups(self, client: DefaultPostgresClient):
-        """Test the search_groups functionality."""
+    def test_search_groups_scoped(self, client: DefaultPostgresClient):
+        """Test the search_groups functionality from a user."""
+        groups = client.search_groups(from_user="user_2")
+        groups = list(groups)
+
+        assert "group_1" in groups
+        assert "group_2" in groups
+        assert "group_3" not in groups
+        assert len(groups) == len(set(groups))
+
+    def test_search_groups_unscoped(self, client: DefaultPostgresClient):
+        """Test the search_groups functionality from any user."""
         groups = client.search_groups()
         groups = list(groups)
 
         assert "group_1" in groups
         assert "group_2" in groups
         assert "group_3" in groups
+        assert len(groups) == len(set(groups))
 
     def test_search_group_memberships(self, client: DefaultPostgresClient):
         """Test the search_group_memberships functionality."""


### PR DESCRIPTION
This PR extends the functionality of the `search_users` and `search_groups` DefaultPostgreSQL [client](https://github.com/canonical/postgresql-ldap-sync/blob/main/src/postgresql_ldap_sync/clients/psql/postgres.py) methods, in order to scope the search within a specific group, or within a specific user memberships.

This modification is key to ensure that, for projects that do not want all their database users to be sync-ed with LDAP (i.e. projects containing a protected set of users), the sync-ing mechanism can be scoped to a particular user group.