### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 
 ## Unreleased
+
+## [0.2.1][changes-0.2.1] - 2025-02-26
 ### Added
 - Ability to search users / groups in a scoped manner.
-### Fixed
 
 ## [0.2.0][changes-0.2.0] - 2025-02-17
 ### Added
@@ -25,5 +26,6 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 [changes-0.1.0]: https://github.com/canonical/postgresql-ldap-sync/releases/tag/v0.1.0
 [changes-0.2.0]: https://github.com/canonical/postgresql-ldap-sync/compare/v0.1.0...v0.2.0
+[changes-0.2.1]: https://github.com/canonical/postgresql-ldap-sync/compare/v0.2.0...v0.2.1
 [docs-changelog]: https://keepachangelog.com/en/1.0.0/
 [docs-semver]: https://semver.org/spec/v2.0.0.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,17 +8,17 @@ description = "Project to sync LDAP users / groups to PostgreSQL"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     { name = "Sinclert Perez", email = "sinclert.perez@canonical.com" }
 ]
 maintainers = [
+    { name = "Sinclert Perez", email = "sinclert.perez@canonical.com" },
     { name = "Carl Csaposs", email = "carl.csaposs@canonical.com" },
     { name = "Dragomir Penev", email = "dragomir.penev@canonical.com" },
     { name = "Marcelo Neppel", email = "marcelo.neppel@canonical.com" },
     { name = "Paulo Silveira", email = "paulo.machado@canonical.com" },
     { name = "Shayan Patel", email = "shayan.patel@canonical.com" },
-    { name = "Sinclert Perez", email = "sinclert.perez@canonical.com" },
 ]
 dependencies = [
     "psycopg2 >= 2.9.0",


### PR DESCRIPTION
This PR makes the necessary changes to release version `0.2.1`.

Depends on https://github.com/canonical/postgresql-ldap-sync/pull/8.