### PR TITLE
Fix potential role deletion crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 ## Unreleased
 ### Added
 - Ability to search LDAP users / groups in a scoped manner.
+### Fixed
+- Possible crash when deleting a user that owns resources.
 
 ## [0.2.1][changes-0.2.1] - 2025-02-26
 ### Added

--- a/tests/clients/psql/test_postgres_client.py
+++ b/tests/clients/psql/test_postgres_client.py
@@ -4,6 +4,7 @@
 import os
 
 import pytest
+from psycopg2.sql import SQL
 
 from postgresql_ldap_sync.clients import DefaultPostgresClient
 from postgresql_ldap_sync.models import GroupMembers
@@ -47,8 +48,31 @@ class TestDefaultPostgresClient:
 
         users = client.search_users()
         users = list(users)
-
         assert "john" in users
+
+    def test_delete_user_without_ownership(self, client: DefaultPostgresClient):
+        """Test the delete_user functionality when the user does not own a resource."""
+        user_name = "user_deleted_without_ownership"
+
+        client.create_user(user_name)
+        client.delete_user(user_name)
+
+        users = client.search_users()
+        users = list(users)
+        assert user_name not in users
+
+    def test_delete_user_with_ownership(self, client: DefaultPostgresClient):
+        """Test the delete_user functionality when the user does own a resource."""
+        user_name = "user_deleted_with_ownership"
+
+        client.create_user(user_name)
+        client._execute_query(SQL("CREATE TABLE user_table (id SERIAL)"))
+        client._execute_query(SQL(f"ALTER TABLE user_table OWNER TO {user_name}"))
+        client.delete_user(user_name)
+
+        users = client.search_users()
+        users = list(users)
+        assert user_name not in users
 
     def test_create_group(self, client: DefaultPostgresClient):
         """Test the create_user functionality."""
@@ -56,8 +80,31 @@ class TestDefaultPostgresClient:
 
         groups = client.search_groups()
         groups = list(groups)
-
         assert "group_rw" in groups
+
+    def test_delete_group_without_ownership(self, client: DefaultPostgresClient):
+        """Test the delete_group functionality when the group does own a resource."""
+        group_name = "group_deleted_without_ownership"
+
+        client.create_group(group_name)
+        client.delete_group(group_name)
+
+        groups = client.search_groups()
+        groups = list(groups)
+        assert group_name not in groups
+
+    def test_delete_group_with_ownership(self, client: DefaultPostgresClient):
+        """Test the delete_group functionality when the group does own a resource."""
+        group_name = "group_deleted_with_ownership"
+
+        client.create_group(group_name)
+        client._execute_query(SQL("CREATE TABLE group_table (id SERIAL)"))
+        client._execute_query(SQL(f"ALTER TABLE group_table OWNER TO {group_name}"))
+        client.delete_group(group_name)
+
+        groups = client.search_groups()
+        groups = list(groups)
+        assert group_name not in groups
 
     def test_search_users_scoped(self, client: DefaultPostgresClient):
         """Test the search_users functionality from a group."""


### PR DESCRIPTION
This PR fixes the logic for deleting a user, in order to avoid crashes when the user owns database resources. The proposed approach has been copied from the PostgreSQL charm library (see [code](https://github.com/canonical/postgresql-k8s-operator/blob/e92a015465cd7556f41cdd1ff51bb02590309a0e/lib/charms/postgresql_k8s/v0/postgresql.py#L305-L320)), where before executing the `DROP` statement, all owned resources are re-assigned to the user issuing the query (usually a system-level user).