### PR TITLE
Allow scoped user / group searches (II)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 
 ## Unreleased
+### Added
+- Ability to search LDAP users / groups in a scoped manner.
 
 ## [0.2.1][changes-0.2.1] - 2025-02-26
 ### Added
-- Ability to search users / groups in a scoped manner.
+- Ability to search PostgreSQL users / groups in a scoped manner.
 
 ## [0.2.0][changes-0.2.0] - 2025-02-17
 ### Added

--- a/src/postgresql_ldap_sync/clients/ldap/base.py
+++ b/src/postgresql_ldap_sync/clients/ldap/base.py
@@ -11,16 +11,16 @@ class BaseLDAPClient(ABC):
     """Base class to interact with an underlying LDAP instance."""
 
     @abstractmethod
-    def search_users(self, filters: list[str] | None = None) -> Iterable[str]:
+    def search_users(self, from_groups: list[str] | None = None) -> Iterable[str]:
         """Search for LDAP users."""
         raise NotImplementedError()
 
     @abstractmethod
-    def search_groups(self, filters: list[str] | None = None) -> Iterable[str]:
+    def search_groups(self, from_users: list[str] | None = None) -> Iterable[str]:
         """Search for LDAP groups."""
         raise NotImplementedError()
 
     @abstractmethod
-    def search_group_memberships(self, filters: list[str] | None = None) -> Iterable[GroupMembers]:
+    def search_group_memberships(self) -> Iterable[GroupMembers]:
         """Search for LDAP group memberships."""
         raise NotImplementedError()

--- a/src/postgresql_ldap_sync/clients/ldap/dummy.py
+++ b/src/postgresql_ldap_sync/clients/ldap/dummy.py
@@ -22,6 +22,6 @@ class DummyLDAPClient(BaseLDAPClient):
         """Search for LDAP groups."""
         return self._groups
 
-    def search_group_memberships(self, _: list[str] | None = None) -> list[GroupMembers]:
+    def search_group_memberships(self) -> list[GroupMembers]:
         """Search for LDAP group memberships."""
         return self._group_memberships

--- a/tests/clients/ldap/test_glauth_client.py
+++ b/tests/clients/ldap/test_glauth_client.py
@@ -24,8 +24,18 @@ class TestGLAuthClient:
             bind_password=os.environ["GLAUTH_PASSWORD"],
         )
 
-    def test_search_users_default_filters(self, client: GLAuthClient):
-        """Test the search_users functionality."""
+    def test_search_users_scoped(self, client: GLAuthClient):
+        """Test the search_users functionality from some groups."""
+        users = client.search_users(from_groups=["danger"])
+        users = list(users)
+
+        assert "danger" in users
+        assert "hackers" not in users
+        assert "johndoe" not in users
+        assert "serviceuser" not in users
+
+    def test_search_users_unscoped(self, client: GLAuthClient):
+        """Test the search_users functionality from any group."""
         users = client.search_users()
         users = list(users)
 
@@ -34,33 +44,23 @@ class TestGLAuthClient:
         assert "johndoe" in users
         assert "serviceuser" in users
 
-    def test_search_users_custom_filters(self, client: GLAuthClient):
-        """Test the search_users functionality."""
-        users = client.search_users(["(accountStatus=inactive)"])
-        users = list(users)
+    def test_search_groups_scoped(self, client: GLAuthClient):
+        """Test the search_groups functionality from some users."""
+        groups = client.search_groups(from_users=["serviceuser"])
+        groups = list(groups)
 
-        assert "danger" not in users
-        assert "hackers" not in users
-        assert "johndoe" not in users
-        assert "serviceuser" not in users
+        assert "danger" not in groups
+        assert "superheros" not in groups
+        assert "svcaccts" in groups
 
-    def test_search_groups_default_filters(self, client: GLAuthClient):
-        """Test the search_groups functionality."""
+    def test_search_groups_unscoped(self, client: GLAuthClient):
+        """Test the search_groups functionality from any user."""
         groups = client.search_groups()
         groups = list(groups)
 
         assert "danger" in groups
         assert "superheros" in groups
         assert "svcaccts" in groups
-
-    def test_search_groups_custom_filters(self, client: GLAuthClient):
-        """Test the search_groups functionality."""
-        groups = client.search_groups(["(cn=danger)"])
-        groups = list(groups)
-
-        assert "danger" in groups
-        assert "superheros" not in groups
-        assert "svcaccts" not in groups
 
     def test_search_group_memberships(self, client: GLAuthClient):
         """Test the search_group_memberships functionality."""


### PR DESCRIPTION
This PR extends the functionality of the `search_users` and `search_groups` GLAuth [client](https://github.com/canonical/postgresql-ldap-sync/blob/main/src/postgresql_ldap_sync/clients/ldap/glauth.py) methods, in order to scope the search within a specific group, or within a specific user memberships.

This modification is key to ensure that, for projects that do not want to synchronize all their LDAP server users, the sync-ing mechanism can be scoped to a particular sub-set of LDAP groups.