### PR TITLE
Fix PostgreSQL grant / revoke empty queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 
 ## Unreleased
+### Fixed
+- Avoid PostgreSQL `GRANT` and `REVOKE` queries when receiving empty lists.
 
 ## [0.3.0][changes-0.3.0] - 2025-03-11
 ### Added

--- a/src/postgresql_ldap_sync/clients/psql/postgres.py
+++ b/src/postgresql_ldap_sync/clients/psql/postgres.py
@@ -169,10 +169,16 @@ class DefaultPostgresClient(BasePostgreClient):
 
     def grant_group_memberships(self, groups: list[str], users: list[str]) -> None:
         """Grant groups membership to a list of users."""
+        if not groups or not users:
+            return
+
         self._grant_role_memberships(groups, users)
 
     def revoke_group_memberships(self, groups: list[str], users: list[str]) -> None:
         """Revoke groups membership from a list of users."""
+        if not groups or not users:
+            return
+
         self._revoke_role_memberships(groups, users)
 
     def search_users(self, from_group: str | None = None) -> Iterator[str]:

--- a/tests/clients/psql/test_postgres_client.py
+++ b/tests/clients/psql/test_postgres_client.py
@@ -123,6 +123,47 @@ class TestDefaultPostgresClient:
         groups = list(groups)
         assert group_name not in groups
 
+    def test_grant_group_memberships(self, client: DefaultPostgresClient):
+        """Test the grant_group_membership functionality."""
+        user_name = "user_grant"
+        group_name = "group_grant"
+
+        client.create_user(user_name)
+        client.create_group(group_name)
+        client.grant_group_memberships([group_name], [user_name])
+
+        users = client.search_users(from_group=group_name)
+        users = list(users)
+        assert user_name in users
+
+        client.delete_user(user_name)
+        client.delete_group(group_name)
+
+    def test_grant_group_memberships_empty(self, client: DefaultPostgresClient):
+        """Test the grant_group_membership functionality with empty lists."""
+        client.grant_group_memberships([], [])
+
+    def test_revoke_group_memberships(self, client: DefaultPostgresClient):
+        """Test the revoke_group_membership functionality."""
+        user_name = "user_revoke"
+        group_name = "group_revoke"
+
+        client.create_user(user_name)
+        client.create_group(group_name)
+        client.grant_group_memberships([group_name], [user_name])
+        client.revoke_group_memberships([group_name], [user_name])
+
+        users = client.search_users(from_group=group_name)
+        users = list(users)
+        assert user_name not in users
+
+        client.delete_user(user_name)
+        client.delete_group(group_name)
+
+    def test_revoke_group_memberships_empty(self, client: DefaultPostgresClient):
+        """Test the revoke_group_membership functionality with empty lists."""
+        client.revoke_group_memberships([], [])
+
     def test_search_users_scoped(self, client: DefaultPostgresClient):
         """Test the search_users functionality from a group."""
         users = client.search_users(from_group="group_1")


### PR DESCRIPTION
This PR fixes the PostgreSQL client in order to avoid issuing `GRANT` and `REVOKE` queries when either the list of groups or the list of users is empty.

This is a **quality of life improvement** for package users that do not want to defensively check for empty lists before calling the `grant_group_memberships` and `revoke_group_memberships` methods. The SQL syntax exceptions were never raised to the package user code as they were intercepted [here](https://github.com/canonical/postgresql-ldap-sync/blob/adfec22277bdbd7b5cbf97903ce3d485f94a5786/src/postgresql_ldap_sync/clients/psql/postgres.py#L132-L133) and [here](https://github.com/canonical/postgresql-ldap-sync/blob/adfec22277bdbd7b5cbf97903ce3d485f94a5786/src/postgresql_ldap_sync/clients/psql/postgres.py#L147-L148), but it would be nice to avoid seeing errors in the logs.