### PR TITLE
Fix PostgreSQL role deletion across databases

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -3,14 +3,14 @@ name: "pg-ldap-sync"
 services:
 
   glauth:
-    image: glauth/glauth:v2.3.2
+    image: docker.io/glauth/glauth:v2.3.2
     ports:
       - "3893:3893"
     volumes:
       - ./tests/_configs/glauth.cfg:/app/config/config.cfg
 
   postgres:
-    image: postgres:16-alpine
+    image: docker.io/postgres:16-alpine
     ports:
       - "5432:5432"
     environment:

--- a/src/postgresql_ldap_sync/clients/psql/postgres.py
+++ b/src/postgresql_ldap_sync/clients/psql/postgres.py
@@ -16,6 +16,57 @@ from .base import BasePostgreClient
 logger = logging.getLogger()
 
 
+class DefaultPostgresExecutor:
+    """Default PostgreSQL query executor."""
+
+    def __init__(
+        self,
+        host: str,
+        port: str,
+        database: str,
+        username: str,
+        password: str,
+        auto_commit: bool = True,
+    ):
+        """Initialize the psycopg2 internal client."""
+        self._connection = psycopg2.connect(
+            host=host,
+            port=port,
+            user=username,
+            password=password,
+            dbname=database,
+        )
+        self._connection.set_session(
+            autocommit=auto_commit,
+        )
+
+    def close(self) -> None:
+        """Close the psycopg2 cursor and connection."""
+        self._connection.close()
+
+    def execute_query(self, query: Composable) -> None:
+        """Execute a SQL query and return the results."""
+        with self._connection.cursor(cursor_factory=RealDictCursor) as cursor:
+            try:
+                cursor.execute(query)
+            except DatabaseError as error:
+                logger.error(error)
+                self._connection.rollback()
+                raise
+
+    def fetch_results(self, query: Composable) -> list[RealDictRow]:
+        """Execute a SQL query and return the results."""
+        with self._connection.cursor(cursor_factory=RealDictCursor) as cursor:
+            try:
+                cursor.execute(query)
+            except DatabaseError as error:
+                logger.error(error)
+                self._connection.rollback()
+                raise
+            else:
+                return cursor.fetchall()
+
+
 class DefaultPostgresClient(BasePostgreClient):
     """Class to interact with an underlying PostgreSQL instance."""
 
@@ -46,40 +97,21 @@ class DefaultPostgresClient(BasePostgreClient):
         auto_commit: bool = True,
     ):
         """Initialize the psycopg2 internal client."""
-        self.username = username
+        self._host = host
+        self._port = port
+        self._database = database
+        self._username = username
+        self._password = password
+        self._auto_commit = auto_commit
 
-        self._client = psycopg2.connect(
+        self._executor = DefaultPostgresExecutor(
             host=host,
             port=port,
-            user=username,
+            database=database,
+            username=username,
             password=password,
-            dbname=database,
+            auto_commit=auto_commit,
         )
-        self._client.set_session(
-            autocommit=auto_commit,
-        )
-
-    def _execute_query(self, query: Composable) -> None:
-        """Execute a SQL query and return the results."""
-        with self._client.cursor(cursor_factory=RealDictCursor) as cursor:
-            try:
-                cursor.execute(query)
-            except DatabaseError as error:
-                logger.error(error)
-                self._client.rollback()
-                raise
-
-    def _fetch_results(self, query: Composable) -> list[RealDictRow]:
-        """Execute a SQL query and return the results."""
-        with self._client.cursor(cursor_factory=RealDictCursor) as cursor:
-            try:
-                cursor.execute(query)
-            except DatabaseError as error:
-                logger.error(error)
-                self._client.rollback()
-                raise
-            else:
-                return cursor.fetchall()
 
     def _create_role(self, role: str, inherit: bool, login: bool) -> None:
         """Create a role in PostgreSQL."""
@@ -93,26 +125,45 @@ class DefaultPostgresClient(BasePostgreClient):
         query = query.format(role=quoted_role)
 
         try:
-            self._execute_query(query)
+            self._executor.execute_query(query)
         except ProgrammingError:
             logger.error(f"Could not create role {quoted_role}")
 
     def _delete_role(self, role: str) -> None:
         """Delete a role in PostgreSQL."""
         quoted_delete_role = Identifier(role)
-        quoted_system_role = Identifier(self.username)
+        quoted_system_role = Identifier(self._username)
 
-        query_1 = SQL("REASSIGN OWNED BY {delete_role} TO {system_role}").format(
+        reassign_query_1 = SQL("REASSIGN OWNED BY {delete_role} TO {system_role}").format(
             delete_role=quoted_delete_role,
             system_role=quoted_system_role,
         )
-        query_2 = SQL("DROP OWNED BY {role}").format(role=quoted_delete_role)
-        query_3 = SQL("DROP ROLE {role}").format(role=quoted_delete_role)
+        reassign_query_2 = SQL("DROP OWNED BY {delete_role}").format(
+            delete_role=quoted_delete_role,
+        )
+        role_drop_query = SQL("DROP ROLE {delete_role}").format(
+            delete_role=quoted_delete_role,
+        )
+
+        for database in self._list_databases(ignored=[self._database]):
+            executor = DefaultPostgresExecutor(
+                host=self._host,
+                port=self._port,
+                database=database,
+                username=self._username,
+                password=self._password,
+                auto_commit=self._auto_commit,
+            )
+            try:
+                executor.execute_query(reassign_query_1)
+                executor.execute_query(reassign_query_2)
+            finally:
+                executor.close()
 
         try:
-            self._execute_query(query_1)
-            self._execute_query(query_2)
-            self._execute_query(query_3)
+            self._executor.execute_query(reassign_query_1)
+            self._executor.execute_query(reassign_query_2)
+            self._executor.execute_query(role_drop_query)
         except ProgrammingError:
             logger.error(f"Could not delete role {quoted_delete_role}")
 
@@ -128,7 +179,7 @@ class DefaultPostgresClient(BasePostgreClient):
         )
 
         try:
-            self._execute_query(query)
+            self._executor.execute_query(query)
         except ProgrammingError:
             logger.error(f"Could not grant memberships to groups {quoted_groups}")
 
@@ -143,13 +194,30 @@ class DefaultPostgresClient(BasePostgreClient):
             users=quoted_users,
         )
         try:
-            self._execute_query(query)
+            self._executor.execute_query(query)
         except ProgrammingError:
             logger.error(f"Could not revoke memberships from groups {quoted_groups}")
 
+    def _list_databases(self, ignored: list[str] | None = None) -> Iterator[str]:
+        """List all databases within the instance."""
+        quoted_ignored = SQL(",").join(Literal(db) for db in ignored)
+
+        query = SQL(
+            "SELECT datname "
+            "FROM pg_catalog.pg_database "
+            "WHERE datname NOT IN ({ignored}) AND datistemplate = false "
+            "ORDER BY 1"
+        )
+
+        query = query.format(ignored=quoted_ignored)
+        rows = self._executor.fetch_results(query)
+
+        for row in rows:
+            yield row["datname"]
+
     def close(self) -> None:
         """Close the psycopg2 cursor and connection."""
-        self._client.close()
+        self._executor.close()
 
     def create_user(self, user: str, inherit: bool = True) -> None:
         """Create a user in PostgreSQL."""
@@ -200,7 +268,7 @@ class DefaultPostgresClient(BasePostgreClient):
         )
 
         query = query.format(group_filter=group_filter.format(group=group_regex))
-        rows = self._fetch_results(query)
+        rows = self._executor.fetch_results(query)
 
         for row in rows:
             user = row["usename"]
@@ -226,7 +294,7 @@ class DefaultPostgresClient(BasePostgreClient):
         )
 
         query = query.format(user_filter=user_filter.format(user=user_regex))
-        rows = self._fetch_results(query)
+        rows = self._executor.fetch_results(query)
 
         for row in rows:
             group = row["groname"]
@@ -242,7 +310,7 @@ class DefaultPostgresClient(BasePostgreClient):
             "JOIN pg_catalog.pg_group ON (pg_auth_members.roleid=pg_group.grosysid) "
             "ORDER BY 1, 2"
         )
-        rows = self._fetch_results(query)
+        rows = self._executor.fetch_results(query)
 
         group_func = lambda row: row["groname"]
         user_func = lambda row: row["usename"]


### PR DESCRIPTION
This PR harmonizes the role deletion procedure with respect to the PostgreSQL charm lib (see [code](https://github.com/canonical/postgresql-operator/blob/fe2c9fbe64307a6391db0432e41a7e28fe801a62/lib/charms/postgresql_k8s/v0/postgresql.py#L350-L370)) in order to reassign every resource belonging to a particular role (user / group), **across all databases**, before dropping it.

The ability to drop roles correctly has become crucial giving the upcoming arrival of _pre-defined roles_, in addition to _custom-roles / role-permissions_ via data-interfaces, as users may now have privileges to create resources in other databases, apart from the one they were initially scoped to.

### Additional changes
- Fixed `compose.yaml` in order to specify images FQDN.