### PR TITLE
[MISC] Merge service definitions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,51 +67,38 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres_image:
-          - 16-alpine
-          - 18-alpine
+        include:
+          - postgres: { version: "16" }
+          - postgres: { version: "18" }
     env:
       GLAUTH_USERNAME: cn=serviceuser,ou=svcaccts,dc=glauth,dc=com
       GLAUTH_PASSWORD: dogood
       POSTGRES_DATABASE: postgres
       POSTGRES_USERNAME: postgres_ldap_sync
       POSTGRES_PASSWORD: postgres_ldap_sync
-    services:
-      glauth:
-        image: glauth/glauth:v2.4.0
-        options: --name glauth
-        ports:
-          - 3893:3893
-      postgres:
-        image: postgres:${{ matrix.postgres_image }}
-        options: --name postgres
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_DB: ${{ env.POSTGRES_DATABASE }}
-          POSTGRES_USER: ${{ env.POSTGRES_USERNAME }}
-          POSTGRES_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v6
-      - name: "Copy GLAuth configuration"
-        run: docker cp ${{ github.workspace }}/tests/_configs/glauth.cfg glauth:/app/config/config.cfg
-      - name: "Restart GLAuth container"
-        run: docker restart glauth
+      - name: "Set up Compose"
+        uses: docker/setup-compose-action@v1
+      - name: "Set up Python"
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
       - name: "Install binaries"
         run: |
           sudo apt update
           sudo apt install libldap2-dev
           sudo apt install libsasl2-dev
-      - name: "Set up Python"
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
       - name: "Install poetry & tox"
         run: |
           pipx install poetry
           pipx install tox
+      - name: "Start services"
+        run: docker compose -f compose/postgresql-${{ matrix.postgres.version }}.yaml up --wait
       - name: "Run tests"
         run: tox run -e integration
+      - name: "Stop services"
+        run: docker compose -f compose/postgresql-${{ matrix.postgres.version }}.yaml down
       - name: "Upload Coverage to Codecov"
         uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ export POSTGRES_DATABASE="..."
 export POSTGRES_USERNAME="..."
 export POSTGRES_PASSWORD="..."
 
-podman-compose -f compose.yaml up --detach && tox -e integration
-podman-compose -f compose.yaml down
+sudo --preserve-env docker compose -f compose/postgresql-16.yaml up --wait && tox -e integration
+sudo --preserve-env docker compose -f compose/postgresql-16.yaml down
 ```
 
 ### Release

--- a/compose/postgresql-16.yaml
+++ b/compose/postgresql-16.yaml
@@ -1,0 +1,19 @@
+name: "postgresql-ldap-sync"
+
+services:
+
+  glauth:
+    image: docker.io/glauth/glauth:v2.3.2
+    ports:
+      - "3893:3893"
+    volumes:
+      - ../tests/_configs/glauth.cfg:/app/config/config.cfg
+
+  postgres:
+    image: docker.io/postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: ${POSTGRES_DATABASE}
+      POSTGRES_USER: ${POSTGRES_USERNAME}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/compose/postgresql-16.yaml
+++ b/compose/postgresql-16.yaml
@@ -3,7 +3,7 @@ name: "postgresql-ldap-sync"
 services:
 
   glauth:
-    image: docker.io/glauth/glauth:v2.3.2
+    image: docker.io/glauth/glauth:v2.4.0
     ports:
       - "3893:3893"
     volumes:

--- a/compose/postgresql-18.yaml
+++ b/compose/postgresql-18.yaml
@@ -3,7 +3,7 @@ name: "postgresql-ldap-sync"
 services:
 
   glauth:
-    image: docker.io/glauth/glauth:v2.3.2
+    image: docker.io/glauth/glauth:v2.4.0
     ports:
       - "3893:3893"
     volumes:

--- a/compose/postgresql-18.yaml
+++ b/compose/postgresql-18.yaml
@@ -1,4 +1,4 @@
-name: "pg-ldap-sync"
+name: "postgresql-ldap-sync"
 
 services:
 
@@ -7,10 +7,10 @@ services:
     ports:
       - "3893:3893"
     volumes:
-      - ./tests/_configs/glauth.cfg:/app/config/config.cfg
+      - ../tests/_configs/glauth.cfg:/app/config/config.cfg
 
   postgres:
-    image: docker.io/postgres:16-alpine
+    image: docker.io/postgres:18-alpine
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
This PR simplifies the CI setup by leveraging the already existing Docker Compose files, instead of defining the services using GitHub Actions limited syntax. An additional benefit of avoiding GitHub Actions native syntax is that the services `command` / `entrypoint` sections can now be overridden at will (see GHA [limitation](https://github.com/orgs/community/discussions/26688))

### Additional changes
- Define a Docker Compose file to test PostgreSQL 18.